### PR TITLE
Add Player Animator dependency and prone knockdown pose

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,7 @@ repositories {
     // flatDir {
     //     dir 'libs'
     // }
+    maven { url 'https://maven.kosmx.dev/' }
 }
 
 dependencies {
@@ -149,6 +150,8 @@ dependencies {
     // The group id is ignored when searching -- in this case, it is "blank"
     // implementation fg.deobf("blank:coolmod-${mc_version}:${coolmod_version}")
 
+    implementation fg.deobf("dev.kosmx.player-anim:player-animation-lib-forge:${player_animator_version}")
+
     // For more info:
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
@@ -165,6 +168,7 @@ tasks.named('processResources', ProcessResources).configure {
             loader_version_range: loader_version_range,
             mod_id: mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
             mod_authors: mod_authors, mod_description: mod_description,
+            player_animator_version_range: player_animator_version_range,
     ]
     inputs.properties replaceProperties
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,8 @@ forge_version=47.3.0
 forge_version_range=[47,)
 # The loader version range can only use the major version of Forge/FML as bounds
 loader_version_range=[47,)
+player_animator_version=1.0.2+1.20
+player_animator_version_range=[1.0.2,)
 # The mapping channel to use for mappings.
 # The default set of supported mapping channels are ["official", "snapshot", "snapshot_nodoc", "stable", "stable_nodoc"].
 # Additional mapping channels can be registered through the "channelProviders" extension in a Gradle plugin.

--- a/src/main/java/net/fretux/knockedback/KnockedManager.java
+++ b/src/main/java/net/fretux/knockedback/KnockedManager.java
@@ -65,6 +65,7 @@ public class KnockedManager {
         knockedEntities.remove(entity.getUUID());
         grippedEntities.remove(entity.getUUID());
         MobKillHandler.clearKillAttempt(entity.getUUID());
+        entity.setForcedPose(null);
         if (entity instanceof ServerPlayer sp) {
             NetworkHandler.CHANNEL.send(
                     PacketDistributor.PLAYER.with(() -> sp),

--- a/src/main/java/net/fretux/knockedback/effects/KnockedEffect.java
+++ b/src/main/java/net/fretux/knockedback/effects/KnockedEffect.java
@@ -1,6 +1,7 @@
 package net.fretux.knockedback.effects;
 
 import net.fretux.knockedback.KnockedManager;
+import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
@@ -20,6 +21,11 @@ public class KnockedEffect {
             player.hurtMarked = true;
             player.setNoGravity(false);
             player.setDeltaMovement(0, player.getDeltaMovement().y(), 0);
+            if (player.getForcedPose() != Pose.SWIMMING) {
+                player.setForcedPose(Pose.SWIMMING);
+            }
+        } else if (player.getForcedPose() == Pose.SWIMMING) {
+            player.setForcedPose(null);
         }
     }
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -63,6 +63,13 @@ description='''${mod_description}'''
     ordering="NONE"
     side="BOTH"
 
+[[dependencies.${mod_id}]]
+    modId="playeranimator"
+    mandatory=true
+    versionRange="${player_animator_version_range}"
+    ordering="NONE"
+    side="BOTH"
+
 # Features are specific properties of the game environment, that you may want to declare you require. This example declares
 # that your mod requires GL version 3.2 or higher. Other features will be added. They are side aware so declaring this won't
 # stop your mod loading on the server for example.


### PR DESCRIPTION
## Summary
- add the Player Animator Maven dependency and expose version properties for resource expansion
- declare Player Animator as a required dependency in the mod descriptor
- force knocked players into a prone swimming pose and clear it when they recover

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d74b7c818832b887e66aad333b4a2)