### PR TITLE
Fix mob execution timer resets, clear respawn knockdown, and sync grip animation

### DIFF
--- a/src/main/java/net/fretux/knockedback/GrippedStatePacket.java
+++ b/src/main/java/net/fretux/knockedback/GrippedStatePacket.java
@@ -1,0 +1,32 @@
+package net.fretux.knockedback;
+
+import net.fretux.knockedback.client.ClientGrippedState;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+public class GrippedStatePacket {
+    private final UUID playerId;
+    private final boolean gripped;
+
+    public GrippedStatePacket(UUID playerId, boolean gripped) {
+        this.playerId = playerId;
+        this.gripped = gripped;
+    }
+
+    public static void encode(GrippedStatePacket packet, FriendlyByteBuf buf) {
+        buf.writeUUID(packet.playerId);
+        buf.writeBoolean(packet.gripped);
+    }
+
+    public static GrippedStatePacket decode(FriendlyByteBuf buf) {
+        return new GrippedStatePacket(buf.readUUID(), buf.readBoolean());
+    }
+
+    public static void handle(GrippedStatePacket packet, Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> ClientGrippedState.setGripped(packet.playerId, packet.gripped));
+        ctx.get().setPacketHandled(true);
+    }
+}

--- a/src/main/java/net/fretux/knockedback/MobKillHandler.java
+++ b/src/main/java/net/fretux/knockedback/MobKillHandler.java
@@ -91,7 +91,11 @@ public class MobKillHandler {
                 setGripped(knocked, false);
                 continue;
             }
-            Mob mob = getMobInRange(knocked);
+            KillAttempt attempt = killAttempts.get(knockedId);
+            Mob mob = attempt != null ? getMobInRangeById(knocked, attempt.mobUuid) : null;
+            if (mob == null) {
+                mob = getMobInRange(knocked);
+            }
             if (mob == null) {
                 if (knocked instanceof ServerPlayer sp) {
                     NetworkHandler.CHANNEL.send(
@@ -103,7 +107,6 @@ public class MobKillHandler {
                 continue;
             }
             setGripped(knocked, true);
-            KillAttempt attempt = killAttempts.get(knockedId);
             if (attempt == null || !attempt.mobUuid.equals(mob.getUUID())) {
                 attempt = new KillAttempt(mob.getUUID(), getExecutionTime());
             } else {
@@ -154,6 +157,19 @@ public class MobKillHandler {
         );
         return world.getEntitiesOfClass(Mob.class, box).stream()
                 .filter(m -> isHostile(m) || isAggressiveNeutral(m, p))
+                .findAny().orElse(null);
+    }
+
+    @Nullable
+    private Mob getMobInRangeById(Player p, UUID mobId) {
+        if (!(p.level() instanceof ServerLevel world)) return null;
+        double r = 2.5;
+        AABB box = new AABB(
+                p.getX() - r, p.getY() - r, p.getZ() - r,
+                p.getX() + r, p.getY() + r, p.getZ() + r
+        );
+        return world.getEntitiesOfClass(Mob.class, box).stream()
+                .filter(m -> m.getUUID().equals(mobId))
                 .findAny().orElse(null);
     }
 

--- a/src/main/java/net/fretux/knockedback/NetworkHandler.java
+++ b/src/main/java/net/fretux/knockedback/NetworkHandler.java
@@ -14,5 +14,6 @@ public class NetworkHandler {
         CHANNEL.registerMessage(id++, KnockedTimePacket.class, KnockedTimePacket::encode, KnockedTimePacket::decode, KnockedTimePacket::handle);
         CHANNEL.registerMessage(id++, ExecutionProgressPacket.class, ExecutionProgressPacket::encode, ExecutionProgressPacket::decode, ExecutionProgressPacket::handle);
         CHANNEL.registerMessage(id++, CarryTogglePacket.class, CarryTogglePacket::encode, CarryTogglePacket::decode, CarryTogglePacket::handle);
+        CHANNEL.registerMessage(id++, GrippedStatePacket.class, GrippedStatePacket::encode, GrippedStatePacket::decode, GrippedStatePacket::handle);
     }
 }

--- a/src/main/java/net/fretux/knockedback/client/ClientGrippedState.java
+++ b/src/main/java/net/fretux/knockedback/client/ClientGrippedState.java
@@ -1,0 +1,21 @@
+package net.fretux.knockedback.client;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class ClientGrippedState {
+    private static final Set<UUID> grippedPlayers = new HashSet<>();
+
+    public static void setGripped(UUID playerId, boolean gripped) {
+        if (gripped) {
+            grippedPlayers.add(playerId);
+        } else {
+            grippedPlayers.remove(playerId);
+        }
+    }
+
+    public static boolean isGripped(UUID playerId) {
+        return grippedPlayers.contains(playerId);
+    }
+}

--- a/src/main/java/net/fretux/knockedback/client/PlayerAnimationHandler.java
+++ b/src/main/java/net/fretux/knockedback/client/PlayerAnimationHandler.java
@@ -1,0 +1,49 @@
+package net.fretux.knockedback.client;
+
+import dev.kosmx.playerAnim.api.layered.IAnimation;
+import dev.kosmx.playerAnim.api.layered.ModifierLayer;
+import dev.kosmx.playerAnim.core.player.KeyframeAnimationPlayer;
+import dev.kosmx.playerAnim.minecraftApi.PlayerAnimationAccess;
+import dev.kosmx.playerAnim.minecraftApi.PlayerAnimationRegistry;
+import net.fretux.knockedback.KnockedBack;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Mod.EventBusSubscriber(modid = KnockedBack.MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class PlayerAnimationHandler {
+    private static final ResourceLocation GRIP_ANIMATION_ID = new ResourceLocation(KnockedBack.MOD_ID, "animation.model.gripping");
+    private static final Map<UUID, ModifierLayer<IAnimation>> layers = new HashMap<>();
+    private static final Map<UUID, Boolean> activeStates = new HashMap<>();
+
+    @SubscribeEvent
+    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) return;
+        if (!(event.player instanceof AbstractClientPlayer player)) return;
+        UUID playerId = player.getUUID();
+        boolean shouldGrip = ClientGrippedState.isGripped(playerId);
+        boolean wasGripping = activeStates.getOrDefault(playerId, false);
+        if (shouldGrip == wasGripping) return;
+        activeStates.put(playerId, shouldGrip);
+        ModifierLayer<IAnimation> layer = layers.computeIfAbsent(playerId, id -> {
+            ModifierLayer<IAnimation> newLayer = new ModifierLayer<>();
+            PlayerAnimationAccess.getPlayerAnimLayer(player).addAnimLayer(newLayer);
+            return newLayer;
+        });
+        if (shouldGrip) {
+            var animation = PlayerAnimationRegistry.getAnimation(GRIP_ANIMATION_ID);
+            if (animation != null) {
+                layer.setAnimation(new KeyframeAnimationPlayer(animation));
+            }
+        } else {
+            layer.setAnimation(null);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent neutral mobs repeatedly resetting the execution countdown so a knocked player can be executed by the original attacker.
- Ensure a player respawning after being executed does not remain knocked for a short time or keep stale execution/grip state.
- Provide a client-side hook into PlayerAnimator to show a gripping animation when the server marks a player as gripped.

### Description

- Keep mob execution attempts tied to the original mob by reusing the existing `KillAttempt` and adding `getMobInRangeById`, so the countdown follows the original mob rather than being restarted by nearby neutrals (`MobKillHandler.java`).
- Broadcast and clear grip/knockdown state on the server by using `setGripped` to send a new `GrippedStatePacket`, and reset knocked/kill state on respawn while sending `KnockedTimePacket` and `ExecutionProgressPacket` to the respawned player (`KnockedManager.java`).
- Add a `GrippedStatePacket` and register it on the network channel (`GrippedStatePacket.java`, `NetworkHandler.java`).
- Add client-side tracking and animation integration: `ClientGrippedState` stores gripped player UUIDs and `PlayerAnimationHandler` uses `PlayerAnimator` APIs (`PlayerAnimationAccess`, `PlayerAnimationRegistry`, `KeyframeAnimationPlayer`, `ModifierLayer`) to play the `animation.model.gripping` animation when a player becomes gripped (`client/ClientGrippedState.java`, `client/PlayerAnimationHandler.java`).

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e2e1bd544832b85cc650d73ffebc3)