### PR TITLE
Fix knocked pose reset to avoid null pose crash

### DIFF
--- a/src/main/java/net/fretux/knockedback/KnockedManager.java
+++ b/src/main/java/net/fretux/knockedback/KnockedManager.java
@@ -4,6 +4,7 @@ import net.fretux.knockedback.config.Config;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Items;
 import net.minecraftforge.event.TickEvent;
@@ -66,7 +67,7 @@ public class KnockedManager {
         knockedEntities.remove(entity.getUUID());
         setGripped(entity, false);
         MobKillHandler.clearKillAttempt(entity.getUUID());
-        entity.setPose(null);
+        entity.setPose(Pose.STANDING);
         if (entity instanceof ServerPlayer sp) {
             NetworkHandler.CHANNEL.send(
                     PacketDistributor.PLAYER.with(() -> sp),


### PR DESCRIPTION
### Motivation

- The server was crashing with an NPE when refreshing entity dimensions due to a null pose being set during knocked-state cleanup. 
- The crash path showed `Player.getStandingEyeHeight` being passed a null `Pose`, leading to an exception during `Entity.refreshDimensions`.

### Description

- Replace the problematic `entity.setPose(null)` call in `KnockedManager.removeKnockedState` with `entity.setPose(Pose.STANDING)` to ensure a valid pose is set. 
- Add the import for `Pose` with `import net.minecraft.world.entity.Pose;` and update the `removeKnockedState` logic accordingly. 
- The change is limited to `src/main/java/net/fretux/knockedback/KnockedManager.java` and ensures players return to a standing pose when unknocked.

### Testing

- No automated tests were executed as part of this change. 
- No test failures reported (no tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e342645bc832ba7713f64e9159df1)