### PR TITLE
Stop forcing swim pose for carried knocked players

### DIFF
--- a/src/main/java/net/fretux/knockedback/effects/KnockedEffect.java
+++ b/src/main/java/net/fretux/knockedback/effects/KnockedEffect.java
@@ -1,6 +1,7 @@
 package net.fretux.knockedback.effects;
 
 import net.fretux.knockedback.KnockedManager;
+import net.fretux.knockedback.CarryManager;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.entity.living.LivingEvent;
@@ -21,7 +22,11 @@ public class KnockedEffect {
             player.hurtMarked = true;
             player.setNoGravity(false);
             player.setDeltaMovement(0, player.getDeltaMovement().y(), 0);
-            if (player.getForcedPose() != Pose.SWIMMING) {
+            if (CarryManager.isBeingCarried(player.getUUID())) {
+                if (player.getForcedPose() == Pose.SWIMMING) {
+                    player.setForcedPose(null);
+                }
+            } else if (player.getForcedPose() != Pose.SWIMMING) {
                 player.setForcedPose(Pose.SWIMMING);
             }
         } else if (player.getForcedPose() == Pose.SWIMMING) {


### PR DESCRIPTION
### Motivation
- Knocked players are forced into the swimming pose which prevents the ride animation from showing while they are being carried.
- Players carried by others should play the ride animation until they are dropped.

### Description
- Update `KnockedEffect.onPlayerTick` to check `CarryManager.isBeingCarried(player.getUUID())` before forcing the swim pose.
- If the player is being carried, clear the forced `Pose.SWIMMING` so the ride animation can play, otherwise preserve the existing swim pose behavior.
- Add an import for `CarryManager` and adjust the pose-setting logic in `src/main/java/net/fretux/knockedback/effects/KnockedEffect.java`.

### Testing
- No automated tests were run for this change.
- Manual behavior: unchanged for non-carried knocked players and clears swim pose for carried knocked players so ride animation can display.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e380cdfe4832bb13e151db1c4e106)