### PR TITLE
Fix knocked swim animation for local player

### DIFF
--- a/src/main/java/net/fretux/knockedback/client/LocalKnockedPoseHandler.java
+++ b/src/main/java/net/fretux/knockedback/client/LocalKnockedPoseHandler.java
@@ -1,0 +1,35 @@
+package net.fretux.knockedback.client;
+
+import net.fretux.knockedback.KnockedBack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = KnockedBack.MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class LocalKnockedPoseHandler {
+    @SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) {
+            return;
+        }
+        Player player = Minecraft.getInstance().player;
+        if (player == null) {
+            return;
+        }
+        if (ClientKnockedState.isKnocked()) {
+            if (player.getVehicle() != null) {
+                if (player.getForcedPose() == Pose.SWIMMING) {
+                    player.setForcedPose(null);
+                }
+            } else if (player.getForcedPose() != Pose.SWIMMING) {
+                player.setForcedPose(Pose.SWIMMING);
+            }
+        } else if (player.getForcedPose() == Pose.SWIMMING) {
+            player.setForcedPose(null);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- The local (client) knocked player did not show the swim/knock animation while remote knocked players did, causing inconsistent visuals.
- The server-side forced pose changes do not always update the local player's client state, so the client must enforce the pose when knocked.

### Description
- Add a new client-side tick handler `LocalKnockedPoseHandler` registered as an `@Mod.EventBusSubscriber` to the client bus.
- On `TickEvent.ClientTickEvent` the handler checks `ClientKnockedState.isKnocked()` and forces `Pose.SWIMMING` on `Minecraft.getInstance().player` when appropriate.
- The handler clears the forced pose when the player is carried (`player.getVehicle() != null`) or when the knocked state ends, preventing lingering swim pose.
- New file added at `src/main/java/net/fretux/knockedback/client/LocalKnockedPoseHandler.java` implementing the above logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e4b951b7c832b85ddd98982240a2b)