### PR TITLE
Add damage_type tag to control knockdown bypass

### DIFF
--- a/src/main/java/net/fretux/knockedback/KnockedBackDamageTags.java
+++ b/src/main/java/net/fretux/knockedback/KnockedBackDamageTags.java
@@ -1,0 +1,16 @@
+package net.fretux.knockedback;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageType;
+
+public final class KnockedBackDamageTags {
+    public static final TagKey<DamageType> BYPASS_KNOCKDOWN = TagKey.create(
+            Registries.DAMAGE_TYPE,
+            new ResourceLocation(KnockedBack.MOD_ID, "bypass_knockdown")
+    );
+
+    private KnockedBackDamageTags() {
+    }
+}

--- a/src/main/java/net/fretux/knockedback/KnockedManager.java
+++ b/src/main/java/net/fretux/knockedback/KnockedManager.java
@@ -167,22 +167,9 @@ public class KnockedManager {
             }
             return;
         }
-        String damageType = src.getMsgId();
         boolean isFatal = player.getHealth() - event.getAmount() <= 0;
         if (isFatal) {
-            if (Config.COMMON.explosionsBypassKnockdown.get() &&
-                    (damageType.contains("explosion") || damageType.contains("fireworks"))) {
-                killAndRemove(player);
-                return;
-            }
-            if (Config.COMMON.fallDamageBypassesKnockdown.get() && damageType.contains("fall")) {
-                killAndRemove(player);
-                return;
-            }
-            if (Config.COMMON.lavaBypassesKnockdown.get() &&
-                    (damageType.contains("lava") || damageType.contains("inFire") ||
-                            damageType.contains("fire") || damageType.contains("onFire") ||
-                            damageType.contains("fireball") || damageType.contains("hotFloor"))) {
+            if (src.is(KnockedBackDamageTags.BYPASS_KNOCKDOWN)) {
                 killAndRemove(player);
                 return;
             }

--- a/src/main/java/net/fretux/knockedback/config/Config.java
+++ b/src/main/java/net/fretux/knockedback/config/Config.java
@@ -16,9 +16,6 @@ public class Config {
         public final ForgeConfigSpec.IntValue knockedDuration;
         public final ForgeConfigSpec.IntValue executionTime;
         public final ForgeConfigSpec.BooleanValue totemPreventsKnockdown;
-        public final ForgeConfigSpec.BooleanValue explosionsBypassKnockdown;
-        public final ForgeConfigSpec.BooleanValue fallDamageBypassesKnockdown;
-        public final ForgeConfigSpec.BooleanValue lavaBypassesKnockdown;
 
         public Common(ForgeConfigSpec.Builder builder) {
             builder.push("general");
@@ -36,18 +33,6 @@ public class Config {
             totemPreventsKnockdown = builder
                     .comment("If true, Totems of Undying prevent entering the knocked state. Default: true.")
                     .define("totemPreventsKnockdown", true);
-
-            explosionsBypassKnockdown = builder
-                    .comment("If true, explosions immediately kill instead of knocking down. Default: true.")
-                    .define("explosionsBypassKnockdown", true);
-
-            fallDamageBypassesKnockdown = builder
-                    .comment("If true, fatal fall damage kills instead of knocking down. Default: true.")
-                    .define("fallDamageBypassesKnockdown", true);
-
-            lavaBypassesKnockdown = builder
-                    .comment("If true, lava or fire damage kills instead of knocking down. Default: true.")
-                    .define("lavaBypassesKnockdown", true);
 
             builder.pop();
         }

--- a/src/main/resources/data/knockedback/tags/damage_type/bypass_knockdown.json
+++ b/src/main/resources/data/knockedback/tags/damage_type/bypass_knockdown.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:explosion",
+    "minecraft:player_explosion",
+    "minecraft:fireworks",
+    "minecraft:fall",
+    "minecraft:lava",
+    "minecraft:in_fire",
+    "minecraft:on_fire",
+    "minecraft:hot_floor",
+    "minecraft:fireball"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Replace multiple hardcoded bypass flags with a single data-driven mechanism so modpack makers can declare which damage types bypass the knocked state. 
- Prevent long-running DOT (damage over time) softlocks by making bypass behavior extensible and configurable via tags. 
- Simplify configuration by moving specific damage-type decisions into tags instead of several boolean `Config` flags.

### Description
- Removed the old per-damage-type bypass config entries from `Config` and kept `totemPreventsKnockdown` intact. 
- Added `KnockedBackDamageTags` exposing a `TagKey<DamageType>` named `BYPASS_KNOCKDOWN` for lookups. 
- Updated `KnockedManager` to check `event.getSource().is(KnockedBackDamageTags.BYPASS_KNOCKDOWN)` when deciding to immediately kill instead of knocking down. 
- Added the default data tag file `data/knockedback/tags/damage_type/bypass_knockdown.json` listing common damage types (e.g. `minecraft:explosion`, `minecraft:fall`, `minecraft:lava`) as initial values.

### Testing
- No automated tests were executed for this change. 
- No automated build or CI verification was run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965f81c3830832bbc3abbb560d21821)