### PR TITLE
Add option to clear potion effects while knocked

### DIFF
--- a/src/main/java/net/fretux/knockedback/config/Config.java
+++ b/src/main/java/net/fretux/knockedback/config/Config.java
@@ -21,6 +21,7 @@ public class Config {
         public final ForgeConfigSpec.BooleanValue totemPreventsKnockdown;
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> mobExecutionAllowlist;
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> knockedPotionEffects;
+        public final ForgeConfigSpec.BooleanValue removeOtherPotionEffectsWhileKnocked;
 
         public Common(ForgeConfigSpec.Builder builder) {
             builder.push("general");
@@ -48,6 +49,10 @@ public class Config {
                             "Format: effect_id,duration,amplifier[,ambient][,visible][,showIcon]",
                             "Example: [\"minecraft:slowness,200,1\", \"minecraft:weakness,200,0,true,false,false\"]")
                     .defineListAllowEmpty("knockedPotionEffects", List.of(), o -> o instanceof String);
+
+            removeOtherPotionEffectsWhileKnocked = builder
+                    .comment("If true, remove any potion effects not listed in knockedPotionEffects while knocked. Default: false.")
+                    .define("removeOtherPotionEffectsWhileKnocked", false);
 
             builder.pop().push("damage_behavior");
 


### PR DESCRIPTION
### Motivation

- Allow specifying which potion effects should be active during the knocked state and prevent other effects from interfering with the intended behavior.
- Provide a toggle so server operators/modpack authors can choose whether to strip all non-configured effects while knocked, preventing unintended interactions (for example, effects that would trigger on low-health). 
- Make knockdown effect application deterministic by preferring the highest amplifier for duplicate effects.

### Description

- Added a new config flag `removeOtherPotionEffectsWhileKnocked` in `Config.java` to control whether non-configured potion effects are removed while a player is knocked. 
- Reworked `KnockedManager.applyKnockedEffects` to build a map of desired effects (choosing the highest amplifier for duplicates), optionally remove any active effects not in that map, and then apply/update the desired effects. 
- Kept the existing effect parsing logic in `parseEffect`, and applied the same refresh/amplifier checks when adding effects.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f456ed3c0832bb30dc048fe9ea2b4)