### PR TITLE
Add changelog documenting changes after 1.4.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes after version 1.4.0 are documented in this file.
+
+## 1.5.2
+- Added a configuration option to remove potion effects not listed in the knocked-effect list while a player is knocked.
+
+## 1.5.1
+- Fixed execution and carry cleanup to prevent stuck execution/carry states when conditions change mid-action.
+
+## 1.5.0
+- Added configuration options for mob execution allowlists and for applying custom potion effects while knocked.
+- Added a master toggle for mob executions and stabilized knocked-state handling.


### PR DESCRIPTION
### Motivation
- Provide a single, human-readable record of notable changes introduced after `1.4.0` so users and contributors can quickly see what changed in subsequent releases.

### Description
- Add `changelog.md` that lists summary entries for `1.5.0`, `1.5.1`, and `1.5.2` including: mob execution allowlist and master toggle, custom potion effects while knocked, execution/carry cleanup fixes, and an option to remove non-listed potion effects while knocked.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f4bd33dec832b973009fd1b863b00)